### PR TITLE
add custom fdroid repo to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ You can get the app on the [Play Store](https://play.google.com/store/apps/detai
 on [GitHub](https://github.com/c3nav/c3nav-android/releases) and on [F-Droid](https://f-droid.org/repository/browse/?fdid=de.c3nav.droid) .
 
 [![Play Store](https://developer.android.com/images/brand/en_app_rgb_wo_60.png)](https://play.google.com/store/apps/details?id=de.c3nav.droid)
-[![Android app on FDroid](https://f-droid.org/wiki/images/c/c4/F-Droid-button_available-on.png)](https://f-droid.org/repository/browse/?fdid=de.c3nav.droid)
+[![Android app on FDroid](https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/Get_it_on_F-Droid_%28material_design%29.svg/190px-Get_it_on_F-Droid_%28material_design%29.svg.png)](https://f-droid.org/repository/browse/?fdid=de.c3nav.droid)
+[![F-Droid repository](https://upload.wikimedia.org/wikipedia/commons/thumb/a/a3/Get_it_on_F-Droid_%28material_design%29.svg/190px-Get_it_on_F-Droid_%28material_design%29.svg.png)](https://f-droid.c3nav.de/fdroid/repo/?fingerprint=C1EC2D062F67A43F87CCF95B8096630285E1B2577DC803A0826539DF6FB4C95D)


### PR DESCRIPTION
see #27

the fdroid button is hotlinked from Wikipedia as the officcial fdroid one is a differents size and resizing in github-markdown is quite ugly