### PR TITLE
Changes for 38C3, fix invalid pinned certificate

### DIFF
--- a/CongressRoutePlanner/app/build.gradle.kts
+++ b/CongressRoutePlanner/app/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
 }
 
 val versionMajor = 4
-val versionMinor = 3
-val versionPatch = 2
+val versionMinor = 4
+val versionPatch = 0
 val minimumSdkVersion = 14
 
 android {
@@ -18,7 +18,7 @@ android {
         targetSdk = 34
         versionCode = generateVersionCode()
         versionName = generateVersionName()
-        buildConfigField("String", "WEB_URL", "\"https://hack-mas24.c3nav.de\"")
+        buildConfigField("String", "WEB_URL", "\"https://38c3.c3nav.de\"")
     }
     signingConfigs {
         create("release") {

--- a/CongressRoutePlanner/app/src/main/java/de/c3nav/droid/MainActivity.java
+++ b/CongressRoutePlanner/app/src/main/java/de/c3nav/droid/MainActivity.java
@@ -268,8 +268,10 @@ public class MainActivity extends AppCompatActivity
                             if (loggedIn) {
                                 uri = MainActivity.this.instanceBaseUrl.buildUpon().encodedPath("/account/").build();
                             } else {
-                                uri = MainActivity.this.instanceBaseUrl.buildUpon().encodedPath("/login")
-                                        .appendQueryParameter("next", Uri.parse(webView.getUrl()).getPath()).build();
+                                uri = MainActivity.this.instanceBaseUrl.buildUpon().encodedPath("/login").build();
+
+                                if (webView.getUrl() != null)
+                                    uri = uri.buildUpon().appendQueryParameter("next", Uri.parse(webView.getUrl()).getPath()).build();
                             }
                             MainActivity.this.evaluateJavascript("window.openInModal ? openInModal('" + uri.toString() + "') : window.location='" + uri.toString() + "';");
                             return true;

--- a/CongressRoutePlanner/app/src/main/res/xml/network_security_config.xml
+++ b/CongressRoutePlanner/app/src/main/res/xml/network_security_config.xml
@@ -3,7 +3,8 @@
     <domain-config cleartextTrafficPermitted="false">
         <domain includeSubdomains="true">c3nav.de</domain>
         <pin-set>
-            <pin digest="SHA-256">K7rZOrXHknnsEhUH8nLL4MZkejquUuIvOIr6tCa0rbo=</pin>
+            <pin digest="SHA-256">C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M=</pin>
+            <pin digest="SHA-256">diGVwiVYbubAI3RW4hB9xU8e/CH2GnkuvVFZE8zmgzI=</pin>
         </pin-set>
     </domain-config>
 </network-security-config>

--- a/CongressRoutePlanner/app/src/main/res/xml/network_security_config.xml
+++ b/CongressRoutePlanner/app/src/main/res/xml/network_security_config.xml
@@ -3,7 +3,7 @@
     <domain-config cleartextTrafficPermitted="false">
         <domain includeSubdomains="true">c3nav.de</domain>
         <pin-set>
-            <pin digest="SHA-256">bdrBhpj38ffhxpubzkINl0rG+UyossdhcBYj+Zx2fcc=</pin>
+            <pin digest="SHA-256">K7rZOrXHknnsEhUH8nLL4MZkejquUuIvOIr6tCa0rbo=</pin>
         </pin-set>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
This changeset changes the basepath to 38c3.c3nav.de.
It also changes the pinned certificate hash to the lets encrypt root since generated LE certs are dynamic, which lead to cert pinning issues when using static cert hashes of the individual cert.
A nullpointer exception is fixed, where if the webview state isn't fully loaded yet, clicking login in the sidebar would lead to a crash.

The Root Cert Hashes for https://letsencrypt.org/certs/isrgrootx1.pem and https://letsencrypt.org/certs/isrg-root-x2.pem can be reproduced like this:
openssl x509 -in rootcert.pem -pubkey -noout | openssl pkey -pubin -outform der | openssl dgst -sha256 -binary | openssl enc -base64