### PR TITLE
ci: add Docker-based APK build workflow and GitHub Action

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,31 @@
+name: Docker APK Build
+
+on:
+  push:
+    branches: [ master, main, 'feature/**' ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  build-apk:
+    name: Build APK with Docker
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
+
+      - name: Build Docker Image & Export APK
+        run: |
+          mkdir -p build-output
+          docker build -t c3nav-android-builder .
+          docker run --rm -v "$(pwd)/build-output:/output" c3nav-android-builder
+
+      - name: Upload APK Artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: c3nav-debug-apk
+          path: build-output/app-debug.apk

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM eclipse-temurin:21-jdk-jammy
+
+ENV ANDROID_HOME=/opt/android-sdk
+ENV PATH=${PATH}:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget unzip git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download and install Android SDK Command-line Tools
+RUN mkdir -p ${ANDROID_HOME}/cmdline-tools && \
+    wget -q https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -O /tmp/cmdline-tools.zip && \
+    unzip -q /tmp/cmdline-tools.zip -d ${ANDROID_HOME}/cmdline-tools && \
+    mv ${ANDROID_HOME}/cmdline-tools/cmdline-tools ${ANDROID_HOME}/cmdline-tools/latest && \
+    rm /tmp/cmdline-tools.zip
+
+# Accept Android SDK licenses and install platform-tools, Android 35 SDK, and Build-Tools 35.0.0
+RUN yes | sdkmanager --licenses && \
+    sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
+
+WORKDIR /app
+COPY . .
+
+WORKDIR /app/CongressRoutePlanner
+RUN chmod +x gradlew && ./gradlew assembleDebug
+
+CMD ["cp", "app/build/outputs/apk/debug/app-debug.apk", "/output/app-debug.apk"]

--- a/README.md
+++ b/README.md
@@ -13,4 +13,13 @@ based on Wifi signals.
 You can get the app on the [Play Store](https://play.google.com/store/apps/details?id=de.c3nav.droid),
 on [GitHub](https://github.com/c3nav/c3nav-android/releases) or our own [F-Droid Repository](https://f-droid.c3nav.de/fdroid/repo/). Installing from the main F-Droid repository is not recommended since releases will often be out of date.
 
+### Building with Docker
+You can compile the Android APK in an isolated container without installing the Android SDK on your host machine:
+
+```bash
+./build-apk-docker.sh
+```
+The output APK will be saved to `./build-output/app-debug.apk`.
+
 [![Play Store](https://developer.android.com/images/brand/en_app_rgb_wo_60.png)](https://play.google.com/store/apps/details?id=de.c3nav.droid)
+

--- a/build-apk-docker.sh
+++ b/build-apk-docker.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+IMAGE_NAME="c3nav-android-builder"
+OUTPUT_DIR="./build-output"
+
+echo "Building Docker image ${IMAGE_NAME}..."
+docker build -t "${IMAGE_NAME}" .
+
+echo "Extracting APK from Docker container..."
+mkdir -p "${OUTPUT_DIR}"
+docker run --rm -v "$(pwd)/${OUTPUT_DIR}:/output" "${IMAGE_NAME}"
+
+echo "APK successfully built and saved to ${OUTPUT_DIR}/app-debug.apk"


### PR DESCRIPTION
Add containerized Android SDK build setup with Dockerfile, helper script build-apk-docker.sh, and GitHub Actions workflow .github/workflows/build-apk.yml to compile the c3nav Android APK without local SDK setup.

This improves adaption of the c3nav app for development builds and custom URLs as well.